### PR TITLE
Fix Rails 6.1 incompatibility by joining with through_table only if it exists

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -2,7 +2,6 @@ module ActiveRecordPostgresEarthdistance
   MILES_TO_METERS_FACTOR = 1609.344
   module ActsAsGeolocated
     extend ActiveSupport::Concern
-    
 
     module ClassMethods  
       def acts_as_geolocated(options = {})
@@ -95,7 +94,7 @@ module ActiveRecordPostgresEarthdistance
   module QueryMethods
     def selecting_distance_from(lat, lng, name = "distance", include_default_columns = true)
       clone.tap do |relation|
-        relation.joins!(through_table)
+        relation.joins!(through_table) if through_table
         values = []
         if relation.select_values.empty? && include_default_columns
           values << relation.arel_table[Arel.star]


### PR DESCRIPTION
Fix Rails 6.1 incompatibility by joining with through_table only if it exists.  

With Rails 6.1 joins args are no longer compacted so a nil value for joins raises an error.  See https://github.com/diogob/activerecord-postgres-earthdistance/pull/48 for same fix to main repo.  

This PR is to fix the Sofar Sounds fork so that this gem can be used immediately with Rails 6.1.  When the fix is made in master in the main repo, Sofar Sounds can point back to the main repo again and stop using this fork.


